### PR TITLE
mcsrch.C: Use itnmax as passed in rather than hard-coded

### DIFF
--- a/src/Base/mcsrch.C
+++ b/src/Base/mcsrch.C
@@ -121,8 +121,8 @@ int mcsrch(NLP1* nlp, ColumnVector& s, ostream *fout, double *stp,
   static double  dgm, dgx, dgy, fxm, fym, stx, sty;
 
   int    siter;
-  //int    maxiter = itnmax;
-  int    maxiter = 10;
+  int    maxiter = itnmax;
+  // int    maxiter = 10;
   int    n = nlp->getDim();
 
   double fvalue;


### PR DESCRIPTION
``itnmax`` represents the maximum number of backtrack linesearch iterations, which is a parameter of the solver that gets passed to ``linesearch.C``. Depending on whether the ``NLF`` is declared as expensive to evaluate or not, either standard backtracking linesearch or More-Thuente linesearch [MT94] is used. The latter had a bug where the maximum number of backtrack iterations was fixed. This PR fixes this.

[MT94] More, J. J. and D. J. Thuente. "Line Search Algorithms with Guaranteed Sufficient Decrease." ACM Transactions on Mathematical Software 20, no. 3 (1994): 286–307.